### PR TITLE
Adding support for custom CAs (issue #11).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ARG TARGETARCH
 COPY ./bin/code-marketplace-linux-$TARGETARCH /opt/code-marketplace
 
 FROM alpine:latest
+RUN apk add ca-certificates
 COPY --chmod=755 --from=binaries /opt/code-marketplace /opt
 
 ENTRYPOINT [ "/opt/code-marketplace", "server" ]

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ export ARTIFACTORY_TOKEN="my-token"
 The token will be used as the `Authorization` header with the value `Bearer
 <TOKEN>`.
 
+## Custom Certificate Authorities for Container Deployment
+
+If your artifactory server or extension download location is on a domain not signed by a default CA, then you will need to add those files either by volume mount or `docker cp` and then run `update-ca-certificates`.
+
 ### Exposing the marketplace
 
 The marketplace must be put behind TLS otherwise code-server will reject

--- a/helm/README.md
+++ b/helm/README.md
@@ -54,6 +54,21 @@ $ kubectl exec -it "$POD_NAME" -- /opt/code-marketplace add https://github.com/V
 In the future it will be possible to use Artifactory for storing and retrieving
 extensions instead of a persistent volume.
 
+## Adding custom certificate authorities
+
+If the location for retrieving extensions (or if using Artifactory storage) is not signed by a common CA, then create a secret in the deployed namespace:
+```
+kubectl create secret -n $namespace generic all-cas --from-file="certificate1.pem"=/path/to/certificate1.pem \
+ --from-file="certificate2.pem"=path/to/certificate2.pem \
+ --from-file="certificate3.pem"=path/to/certificate3.pem
+```
+
+And then, set the certificates.secretName to match:
+
+```console
+$ helm upgrade --install code-marketplace ./helm-chart --set certificates.secretName "all-cas"
+```
+
 ## Uninstall
 
 To uninstall/delete the marketplace deployment:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -30,6 +30,16 @@ spec:
         - name: extensions
           persistentVolumeClaim:
             claimName: {{ include "code-marketplace.fullname" . }}
+        {{- if .Values.certificates.secretName }}
+        - name: certs
+          secret:
+            secretName: {{ .Values.certificates.secretName }}
+        {{- end }}
+      {{- else if and .Values.persistence.artifactory.enabled .Values.certificates.secretName }}
+      volumes:
+        - name: certs
+          secret:
+            secretName: {{ .Values.certificates.secretName }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -39,6 +49,13 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.certificates.secretName }}
+          lifecycle:           
+            postStart:             
+              exec:               
+                command:              
+                  - update-ca-certificates
+          {{- end}}
           {{- if .Values.persistence.artifactory.enabled }}
           env:
             - name: "ARTIFACTORY_TOKEN"
@@ -67,6 +84,14 @@ spec:
           volumeMounts:
             - name: extensions
               mountPath: /extensions
+            {{- if .Values.certificates.secretName }}
+            - name: certs
+              mountPath: /usr/local/share/ca-certificates/
+            {{- end }}
+          {{- else if and .Values.persistence.artifactory.enabled .Values.certificates.secretName }}
+          volumeMounts:
+            - name: certs
+              mountPath: /usr/local/share/ca-certificates/
           {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -93,3 +93,10 @@ persistence:
     repo: extensions
   # Size is ignored when using Artifactory.
   size: 100Gi
+
+# Create a secret with all additional certificate authorities, ex:
+# kubectl create secret -n $namespace generic all-cas --from-file="certificate1.pem"=/path/to/certificate1.pem \
+# --from-file="certificate2.pem"=path/to/certificate2.pem \
+# --from-file="certificate3.pem"=path/to/certificate3.pem
+certificates:
+  secretName: "" 


### PR DESCRIPTION
Updated Dockerfile to install ca-certificates
Updated the deployment.yaml and added:
    A poststart lifecycle hook to run `update-ca-certificates`
    volume definition certs that maps to .Values.certificates.secretName
    volumeMounts that mount the secret to /usr/local/share/ca-certificates/
    Both of these generate if persistence is enabled or not (to ensure that if neither persistence or artifactory are specified, but certificates is, that the yaml is still correct.
Updated the values.yaml to add
    certificates:
        secretName: ""
Along with some corresponding updates to the README.md files in root and helm chart.

TESTING:
Testing was accomplished by creating a separate Dockerfile which was just FROM the existing v1.2.1 image and adding ca-certificates. A values file was created that:
1. Used this image
2. set certificates.secretName
3. Set ingress information
4. Set artifactory.enabled to true and configured it against my private artifactory.

Testing was positive:
```
/opt # ./code-marketplace -v add ms-python.python-2023.5.10672245.vsix --artifactory https://artifactory.local.domain/artifactory --repo vscode-extensions
2023-03-16 20:03:56.653 [INFO]<artifactory.go:88>Seeding manifest cache...
2023-03-16 20:03:56.717 [DEBUG]<artifactory.go:135>artifactory request{"path": "api/storage/vscode-extensions?list\u0026deep=1\u0026depth=3\u0026listFolders=1", "method": "GET", "took": "63.398861ms"}
2023-03-16 20:03:56.717 [DEBUG]<artifactory.go:178>parse list response{"took": "305.9µs"}
2023-03-16 20:03:56.718 [INFO]<artifactory.go:120>Seeded manifest cache{"count": 0, "took": "64.410262ms"}
2023-03-16 20:03:57.022 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension.vsixmanifest", "method": "PUT", "took": "290.632781ms"}
2023-03-16 20:03:57.165 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/CHANGELOG.md", "method": "PUT", "took": "142.379237ms"}
2023-03-16 20:03:57.295 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/dist/extension.browser.js", "method": "PUT", "took": "129.862626ms"}
2023-03-16 20:03:57.345 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/dist/extension.browser.js.LICENSE.txt", "method": "PUT", "took": "49.677148ms"}
2023-03-16 20:03:57.400 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/icon.png", "method": "PUT", "took": "55.143953ms"}
2023-03-16 20:03:57.454 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/LICENSE.txt", "method": "PUT", "took": "53.012451ms"}
2023-03-16 20:03:57.509 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/package.json", "method": "PUT", "took": "54.904753ms"}
2023-03-16 20:03:57.561 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/extension/README.md", "method": "PUT", "took": "45.820144ms"}
2023-03-16 20:03:58.209 [DEBUG]<artifactory.go:135>artifactory request{"path": "vscode-extensions/ms-python/python/2023.5.10672245/ms-python.python-2023.5.10672245.vsix", "method": "PUT", "took": "647.480824ms"}
Unpacked ms-python.python-2023.5.10672245 to https://artifactory.local.domain/artifactory/ms-python/python/2023.5.10672245
  - ms-python.python-2023.5.10672245 has 0 dependencies
  - ms-python.python-2023.5.10672245 is in a pack with 2 other extensions
    - ms-toolsai.jupyter
    - ms-python.vscode-pylance
```