### PR TITLE
🔗 Add `code-marketplace` to `$PATH`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,6 @@ COPY ./bin/code-marketplace-linux-$TARGETARCH /opt/code-marketplace
 
 FROM alpine:latest
 COPY --chmod=755 --from=binaries /opt/code-marketplace /opt
+RUN ln -s /opt/code-marketplace /usr/local/bin/code-marketplace
 
 ENTRYPOINT [ "/opt/code-marketplace", "server" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ FROM alpine:latest
 COPY --chmod=755 --from=binaries /opt/code-marketplace /opt
 RUN ln -s /opt/code-marketplace /usr/local/bin/code-marketplace
 
-ENTRYPOINT [ "/opt/code-marketplace", "server" ]
+ENTRYPOINT [ "code-marketplace", "server" ]


### PR DESCRIPTION
Add `code-marketplace` to `$PATH` so that it does not need to be executed absolutely *(i.e. `/opt/code-marketplace`)*.