### PR TITLE
✏️ Make the executable name consistent with documentation

### DIFF
--- a/cli/root.go
+++ b/cli/root.go
@@ -7,12 +7,12 @@ import (
 
 func Root() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "marketplace",
+		Use:           "code-marketplace",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Long:          "Code extension marketplace",
 		Example: strings.Join([]string{
-			"  marketplace server --extensions-dir ./extensions",
+			"  code-marketplace server --extensions-dir ./extensions",
 		}, "\n"),
 	}
 


### PR DESCRIPTION
Make the executable name consistent with documentation which uses `code-marketplace`.
Whereas the *usage* and *help* for the CLI uses `marketplace`.