### PR TITLE
BREAKING CHANGE: Amend version identifier in ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Extensions can be removed from the marketplace by ID and version or `--all` to
 remove all versions.
 
 ```console
-./code-marketplace remove ms-python.python-2022.14.0 [flags]
+./code-marketplace remove ms-python.python@2022.14.0 [flags]
 ./code-marketplace remove ms-python.python --all [flags]
 ```
 

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -29,7 +29,7 @@ func remove() *cobra.Command {
 		Use:   "remove <id>",
 		Short: "Remove an extension from the marketplace",
 		Example: strings.Join([]string{
-			"  marketplace remove publisher.extension-1.0.0 --extensions-dir ./extensions",
+			"  marketplace remove publisher.extension@1.0.0 --extensions-dir ./extensions",
 			"  marketplace remove publisher.extension --all --artifactory http://artifactory.server/artifactory --repo extensions",
 		}, "\n"),
 		Args: cobra.ExactArgs(1),
@@ -78,7 +78,7 @@ func remove() *cobra.Command {
 				return xerrors.Errorf("%s.%s has no versions to delete", publisher, name)
 			} else if version == "" && !all {
 				return xerrors.Errorf(
-					"use %s-<version> to target a specific version or pass --all to delete %s of %s",
+					"use %s@<version> to target a specific version or pass --all to delete %s of %s",
 					id,
 					util.Plural(versionCount, "version", ""),
 					id,
@@ -94,7 +94,7 @@ func remove() *cobra.Command {
 				removedCount := len(allVersions)
 				summary = append(summary, fmt.Sprintf("Removed %s", util.Plural(removedCount, "version", "")))
 				for _, version := range allVersions {
-					summary = append(summary, fmt.Sprintf("  - %s", version))
+					summary = append(summary, fmt.Sprintf("  @ %s", version))
 				}
 			} else {
 				summary = append(summary, fmt.Sprintf("Removed %s", version))

--- a/cli/remove.go
+++ b/cli/remove.go
@@ -94,7 +94,7 @@ func remove() *cobra.Command {
 				removedCount := len(allVersions)
 				summary = append(summary, fmt.Sprintf("Removed %s", util.Plural(removedCount, "version", "")))
 				for _, version := range allVersions {
-					summary = append(summary, fmt.Sprintf("  @ %s", version))
+					summary = append(summary, fmt.Sprintf("  - %s", version))
 				}
 			} else {
 				summary = append(summary, fmt.Sprintf("Removed %s", version))

--- a/cli/remove_test.go
+++ b/cli/remove_test.go
@@ -108,7 +108,7 @@ func TestRemove(t *testing.T) {
 
 			id := fmt.Sprintf("%s.%s", test.extension.Publisher, test.extension.Name)
 			if test.version != "" {
-				id = fmt.Sprintf("%s-%s", id, test.version)
+				id = fmt.Sprintf("%s@%s", id, test.version)
 			}
 
 			cmd := cli.Root()

--- a/fixtures/generate.bash
+++ b/fixtures/generate.bash
@@ -105,7 +105,7 @@ EOF
       cat<<EOF > "$dest/extension/extension.js"
 const vscode = require("vscode");
 function activate(context) {
-  vscode.window.showInformationMessage("mock extension $publisher.$name-$version loaded");
+  vscode.window.showInformationMessage("mock extension $publisher.$name@$version loaded");
 }
 exports.activate = activate;
 EOF
@@ -121,8 +121,8 @@ mock changelog
 EOF
       cp "$dir/icon.png" "$dest/extension/images/icon.png"
       pushd "$dest" >/dev/null
-      rm "$publisher.$name-$version.vsix"
-      zip -r "$publisher.$name-$version.vsix" * -q
+      rm "$publisher.$name@$version.vsix"
+      zip -r "$publisher.$name@$version.vsix" * -q
       popd >/dev/null
     done < "$dir/versions"
   done < "$dir/names"

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -250,16 +250,16 @@ func ExtensionIDFromManifest(manifest *VSIXManifest) string {
 
 // ExtensionID returns the full ID of an extension.
 func ExtensionID(publisher, name, version string) string {
-	return fmt.Sprintf("%s.%s-%s", publisher, name, version)
+	return fmt.Sprintf("%s.%s@%s", publisher, name, version)
 }
 
 // ParseExtensionID parses an extension ID into its separate parts: publisher,
 // name, and version (version may be blank).
 func ParseExtensionID(id string) (string, string, string, error) {
-	re := regexp.MustCompile(`^([^.]+)\.([^-]+)-?(.*)$`)
+	re := regexp.MustCompile(`^([^.]+)\.([^@]+)@?(.*)$`)
 	match := re.FindAllStringSubmatch(id, -1)
 	if match == nil {
-		return "", "", "", xerrors.Errorf("\"%s\" does not match <publisher>.<name> or <publisher>.<name>-<version>", id)
+		return "", "", "", xerrors.Errorf("\"%s\" does not match <publisher>.<name> or <publisher>.<name>@<version>", id)
 	}
 	return match[0][1], match[0][2], match[0][3], nil
 }

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -230,7 +230,7 @@ func testManifest(t *testing.T, factory storageFactory) {
 			name:      "MissingVersion",
 			error:     fs.ErrNotExist,
 			extension: testutil.Extensions[0],
-			version:   "some-nonexistent-version",
+			version:   "some-nonexistent@version",
 		},
 		{
 			name:      "MissingExtension",
@@ -275,7 +275,7 @@ func testManifest(t *testing.T, factory storageFactory) {
 				// manifest since it is not on the actual manifest on disk.
 				expected.Assets.Asset = append(expected.Assets.Asset, storage.VSIXAsset{
 					Type:        storage.VSIXAssetType,
-					Path:        fmt.Sprintf("%s.%s-%s.vsix", test.extension.Publisher, test.extension.Name, version),
+					Path:        fmt.Sprintf("%s.%s@%s.vsix", test.extension.Publisher, test.extension.Name, version),
 					Addressable: "true",
 				})
 				require.NoError(t, err)
@@ -335,7 +335,7 @@ func testWalkExtensions(t *testing.T, factory storageFactory) {
 				// manifest since it is not on the actual manifest on disk.
 				manifest.Assets.Asset = append(manifest.Assets.Asset, storage.VSIXAsset{
 					Type:        storage.VSIXAssetType,
-					Path:        fmt.Sprintf("%s.%s-%s.vsix", ext.Publisher, ext.Name, ext.LatestVersion),
+					Path:        fmt.Sprintf("%s.%s@%s.vsix", ext.Publisher, ext.Name, ext.LatestVersion),
 					Addressable: "true",
 				})
 				expected = append(expected, extension{
@@ -734,7 +734,7 @@ func testAddExtension(t *testing.T, factory storageFactory) {
 	// Put a directory in the way of the vsix.
 	f := factory(t)
 	ext := testutil.Extensions[3]
-	vsixName := fmt.Sprintf("%s.%s-%s.vsix", ext.Publisher, ext.Name, ext.LatestVersion)
+	vsixName := fmt.Sprintf("%s.%s@%s.vsix", ext.Publisher, ext.Name, ext.LatestVersion)
 	f.write([]byte("foo"), ext.Publisher, ext.Name, ext.LatestVersion, vsixName, "foo")
 
 	for _, test := range tests {
@@ -909,7 +909,7 @@ func TestExtensionID(t *testing.T) {
 	}{
 		{
 			name:     "OK",
-			expected: "foo.bar-test",
+			expected: "foo.bar@test",
 			manifest: &storage.VSIXManifest{
 				Metadata: storage.VSIXMetadata{
 					Identity: storage.VSIXIdentity{
@@ -948,12 +948,12 @@ func TestParseExtensionID(t *testing.T) {
 		{
 			name:     "OK",
 			expected: []string{"foo", "bar", "test"},
-			id:       "foo.bar-test",
+			id:       "foo.bar@test",
 		},
 		{
 			name:     "VersionWithDots",
 			expected: []string{"foo", "bar", "test.test"},
-			id:       "foo.bar-test.test",
+			id:       "foo.bar@test.test",
 		},
 		{
 			name:  "EmptyID",
@@ -963,12 +963,12 @@ func TestParseExtensionID(t *testing.T) {
 		{
 			name:  "MissingPublisher",
 			error: true,
-			id:    ".qux-bar",
+			id:    ".qux@bar",
 		},
 		{
 			name:  "MissingExtension",
 			error: true,
-			id:    "foo.-baz",
+			id:    "foo.@baz",
 		},
 		{
 			name:  "MissingExtensionAndVersion",
@@ -983,7 +983,7 @@ func TestParseExtensionID(t *testing.T) {
 		{
 			name:  "InvalidID",
 			error: true,
-			id:    "publisher-version",
+			id:    "publisher@version",
 		},
 	}
 


### PR DESCRIPTION
Amend the version identifier from `publisher.extension-version` to `publisher.extension@1.0.0`.
In an effort to address #23 

*Note:* This is a breaking change as it amends the extension ID and so will change the way extensions are removed from Code Marketplace