### PR TITLE
Feature/local storage cache

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -27,7 +27,7 @@ func server() *cobra.Command {
 		artifactory       string
 		extdir            string
 		repo              string
-		listcacheduration int
+		listcacheduration time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -58,7 +58,7 @@ func server() *cobra.Command {
 				ExtDir:            extdir,
 				Logger:            logger,
 				Repo:              repo,
-				ListCacheDuration: time.Duration(listcacheduration) * time.Minute,
+				ListCacheDuration: listcacheduration,
 			})
 			if err != nil {
 				return err
@@ -139,7 +139,7 @@ func server() *cobra.Command {
 	cmd.Flags().StringVar(&artifactory, "artifactory", "", "Artifactory server URL.")
 	cmd.Flags().StringVar(&repo, "repo", "", "Artifactory repository.")
 	cmd.Flags().StringVar(&address, "address", "127.0.0.1:3001", "The address on which to serve the marketplace API.")
-	cmd.Flags().IntVar(&listcacheduration, "list-cache-duration", 1, "The duration of the extension cache in minutes.")
+	cmd.Flags().DurationVar(&listcacheduration, "list-cache-duration", time.Minute, "The duration of the extension cache.")
 
 	return cmd
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -23,10 +23,11 @@ import (
 
 func server() *cobra.Command {
 	var (
-		address     string
-		artifactory string
-		extdir      string
-		repo        string
+		address           string
+		artifactory       string
+		extdir            string
+		repo              string
+		listcacheduration int
 	)
 
 	cmd := &cobra.Command{
@@ -53,10 +54,11 @@ func server() *cobra.Command {
 			}
 
 			store, err := storage.NewStorage(ctx, &storage.Options{
-				Artifactory: artifactory,
-				ExtDir:      extdir,
-				Logger:      logger,
-				Repo:        repo,
+				Artifactory:       artifactory,
+				ExtDir:            extdir,
+				Logger:            logger,
+				Repo:              repo,
+				ListCacheDuration: time.Duration(listcacheduration) * time.Minute,
 			})
 			if err != nil {
 				return err
@@ -137,6 +139,7 @@ func server() *cobra.Command {
 	cmd.Flags().StringVar(&artifactory, "artifactory", "", "Artifactory server URL.")
 	cmd.Flags().StringVar(&repo, "repo", "", "Artifactory repository.")
 	cmd.Flags().StringVar(&address, "address", "127.0.0.1:3001", "The address on which to serve the marketplace API.")
+	cmd.Flags().IntVar(&listcacheduration, "list-cache-duration", 1, "The duration of the extension cache in minutes.")
 
 	return cmd
 }

--- a/storage/artifactory.go
+++ b/storage/artifactory.go
@@ -333,13 +333,6 @@ func (s *Artifactory) RemoveExtension(ctx context.Context, publisher, name strin
 	return err
 }
 
-type extension struct {
-	manifest  *VSIXManifest
-	name      string
-	publisher string
-	versions  []Version
-}
-
 func (s *Artifactory) listWithCache(ctx context.Context) *[]ArtifactoryFile {
 	s.listMutex.Lock()
 	defer s.listMutex.Unlock()

--- a/storage/local.go
+++ b/storage/local.go
@@ -27,8 +27,8 @@ type Local struct {
 }
 
 type LocalOptions struct {
-	// How long to cache list responses.  Zero means no cache.  Manifests are
-	// currently cached indefinitely since they do not change.
+	// How long to cache the list of extensions with their manifests.  Zero means 
+	// no cache.
 	ListCacheDuration time.Duration
 	ExtDir            string
 }

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -15,7 +15,7 @@ import (
 func localFactory(t *testing.T) testStorage {
 	extdir := t.TempDir()
 	logger := slogtest.Make(t, &slogtest.Options{IgnoreErrors: true}).Leveled(slog.LevelDebug)
-	s, err := storage.NewLocalStorage(extdir, logger)
+	s, err := storage.NewLocalStorage(&storage.LocalOptions{ExtDir: extdir}, logger)
 	require.NoError(t, err)
 	return testStorage{
 		storage: s,

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -129,6 +129,13 @@ type Options struct {
 	Logger      slog.Logger
 }
 
+type extension struct {
+	manifest  *VSIXManifest
+	name      string
+	publisher string
+	versions  []Version
+}
+
 // Version is a subset of database.ExtVersion.
 type Version struct {
 	TargetPlatform Platform `json:"targetPlatform,omitempty"`

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -123,10 +123,11 @@ type VSIXAsset struct {
 }
 
 type Options struct {
-	Artifactory string
-	ExtDir      string
-	Repo        string
-	Logger      slog.Logger
+	Artifactory       string
+	ExtDir            string
+	Repo              string
+	Logger            slog.Logger
+	ListCacheDuration time.Duration
 }
 
 type extension struct {
@@ -245,14 +246,17 @@ func NewStorage(ctx context.Context, options *Options) (Storage, error) {
 			return nil, xerrors.Errorf("the %s environment variable must be set", ArtifactoryTokenEnvKey)
 		}
 		return NewArtifactoryStorage(ctx, &ArtifactoryOptions{
-			ListCacheDuration: time.Minute,
+			ListCacheDuration: options.ListCacheDuration,
 			Logger:            options.Logger,
 			Repo:              options.Repo,
 			Token:             token,
 			URI:               options.Artifactory,
 		})
 	} else if options.ExtDir != "" {
-		return NewLocalStorage(options.ExtDir, options.Logger)
+		return NewLocalStorage(&LocalOptions{
+			ListCacheDuration: options.ListCacheDuration,
+			ExtDir:            options.ExtDir,
+		}, options.Logger)
 	}
 	return nil, xerrors.Errorf("must provide an Artifactory repository or local directory")
 }


### PR DESCRIPTION
This PR adds a cache to extensions read from the file system, similar to the one used for extensions read from an Artifactory repository.

My use case is that i have many (6000+) extensions with different versions on disk, and walking through all of them takes upwards of 3 minutes for every single API call. With a cache in place, I can instead pre-fill the cache at regular time intervals, and respond to API calls within ~300 milliseconds.

I have tried to emulate the existing code style with my changes, but my Go skills are admittedly a bit rusty, so I welcome any feedback, and will try to make changes as best I can.

This PR also does not address the issue of evicting the cache on adding/removing extensions that has been noted in a TODO in the Artifactory implementation, but hopefully that can be tackled as a future improvement.