### PR TITLE
add -f to rm mock extension file in /fixtures/generate

### DIFF
--- a/fixtures/generate.bash
+++ b/fixtures/generate.bash
@@ -121,7 +121,7 @@ mock changelog
 EOF
       cp "$dir/icon.png" "$dest/extension/images/icon.png"
       pushd "$dest" >/dev/null
-      rm "$publisher.$name@$version.vsix"
+      rm -f "$publisher.$name@$version.vsix"
       zip -r "$publisher.$name@$version.vsix" * -q
       popd >/dev/null
     done < "$dir/versions"


### PR DESCRIPTION
This fixes a bug where running make gen failed on first run because the file you're trying to delete and replace never existed to begin with.