### PR TITLE
chore: log hostname in verbose request logs

### DIFF
--- a/api/httpmw/logger.go
+++ b/api/httpmw/logger.go
@@ -15,6 +15,7 @@ func Logger(log slog.Logger) func(next http.Handler) http.Handler {
 			sw := &httpapi.StatusWriter{ResponseWriter: w}
 
 			httplog := log.With(
+				slog.F("host", r.Host),
 				slog.F("path", r.URL.Path),
 				slog.F("remote_addr", r.RemoteAddr),
 				slog.F("client_id", r.Header.Get("x-market-client-id")),


### PR DESCRIPTION
Hosting the marketplace behind a reverse proxy, this was just nice when I was hitting if from infront and behind the proxy.