### PR TITLE
chore: sign the vsix package, not the manifest

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -31,6 +31,8 @@ func serverFlags() (addFlags func(cmd *cobra.Command), opts *storage.Options) {
 		cmd.Flags().StringVar(&opts.Repo, "repo", "", "Artifactory repository.")
 		cmd.Flags().BoolVar(&sign, "sign", false, "Sign extensions.")
 		_ = cmd.Flags().MarkHidden("sign") // This flag needs to import a key, not just be a bool
+		cmd.Flags().BoolVar(&opts.SaveSigZips, "save-sigs", false, "Save signed extensions to disk for debugging.")
+		_ = cmd.Flags().MarkHidden("save-sigs")
 
 		if cmd.Use == "server" {
 			// Server only flags

--- a/extensionsign/sigzip.go
+++ b/extensionsign/sigzip.go
@@ -28,7 +28,7 @@ func ExtractSignatureManifest(zip []byte) (SignatureManifest, error) {
 }
 
 // SignAndZipManifest signs a manifest and zips it up
-func SignAndZipManifest(secret crypto.Signer, manifest json.RawMessage) ([]byte, error) {
+func SignAndZipManifest(secret crypto.Signer, vsixData []byte, manifest json.RawMessage) ([]byte, error) {
 	var buf bytes.Buffer
 	w := zip.NewWriter(&buf)
 
@@ -54,7 +54,7 @@ func SignAndZipManifest(secret crypto.Signer, manifest json.RawMessage) ([]byte,
 		return nil, xerrors.Errorf("create signature: %w", err)
 	}
 
-	signature, err := secret.Sign(rand.Reader, manifest, crypto.Hash(0))
+	signature, err := secret.Sign(rand.Reader, vsixData, crypto.Hash(0))
 	if err != nil {
 		return nil, xerrors.Errorf("sign: %w", err)
 	}

--- a/storage/signature_test.go
+++ b/storage/signature_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"testing"
 
+	"cdr.dev/slog"
 	"github.com/coder/code-marketplace/extensionsign"
 	"github.com/coder/code-marketplace/storage"
 )
@@ -28,7 +29,7 @@ func signed(signer bool, factory func(t *testing.T) testStorage) func(t *testing
 		}
 
 		return testStorage{
-			storage:          storage.NewSignatureStorage(key, st.storage),
+			storage:          storage.NewSignatureStorage(slog.Make(), key, st.storage),
 			write:            st.write,
 			exists:           st.exists,
 			expectedManifest: exp,

--- a/storage/signature_test.go
+++ b/storage/signature_test.go
@@ -11,7 +11,7 @@ import (
 func expectSignature(manifest *storage.VSIXManifest) {
 	manifest.Assets.Asset = append(manifest.Assets.Asset, storage.VSIXAsset{
 		Type:        storage.VSIXSignatureType,
-		Path:        storage.SigzipFilename,
+		Path:        storage.SigzipFileExtension,
 		Addressable: "true",
 	})
 }

--- a/storage/signature_test.go
+++ b/storage/signature_test.go
@@ -12,7 +12,7 @@ import (
 func expectSignature(manifest *storage.VSIXManifest) {
 	manifest.Assets.Asset = append(manifest.Assets.Asset, storage.VSIXAsset{
 		Type:        storage.VSIXSignatureType,
-		Path:        storage.SigzipFileExtension,
+		Path:        storage.SignatureZipFilename(manifest),
 		Addressable: "true",
 	})
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -132,8 +132,12 @@ type Options struct {
 	Artifactory       string
 	ExtDir            string
 	Repo              string
+	SaveSigZips       bool
 	Logger            slog.Logger
 	ListCacheDuration time.Duration
+	// SaveSigZips is a flag that will save the signed extension to disk.
+	// This is useful for debugging, but the server will never use this file.
+	saveSigZips bool
 }
 
 type extension struct {
@@ -293,7 +297,12 @@ func NewStorage(ctx context.Context, options *Options) (Storage, error) {
 		return nil, err
 	}
 
-	return NewSignatureStorage(options.Signer, store), nil
+	signingStorage := NewSignatureStorage(options.Logger, options.Signer, store)
+	if options.SaveSigZips {
+		signingStorage.SaveSigZips()
+	}
+
+	return signingStorage, nil
 }
 
 // ReadVSIXManifest reads and parses an extension manifest from a vsix file.  If

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -135,9 +135,6 @@ type Options struct {
 	SaveSigZips       bool
 	Logger            slog.Logger
 	ListCacheDuration time.Duration
-	// SaveSigZips is a flag that will save the signed extension to disk.
-	// This is useful for debugging, but the server will never use this file.
-	saveSigZips bool
 }
 
 type extension struct {


### PR DESCRIPTION
I misread the nodejs implementation, see this line: filepath.Join(filepath.Dir(fp), vsixPath+".vsix")

Should be signing the vsix file.

Regardless, signatures are still not being checked :man_shrugging:. Unsure why VSCode just accepts bad signatures :thinking:.

Also adds a command line flag to save the signatures to disk. Really nice for debugging.