### PR TITLE
chore: revert back to FileServer returning an http handler

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -112,7 +112,7 @@ func New(options *Options) *API {
 	r.Post("/api/extensionquery", api.extensionQuery)
 
 	// Endpoint for getting an extension's files or the extension zip.
-	r.Mount("/files", http.StripPrefix("/files", storage.HTTPFileServer(options.Storage)))
+	r.Mount("/files", http.StripPrefix("/files", options.Storage.FileServer()))
 
 	// VS Code can use the files in the response to get file paths but it will
 	// sometimes ignore that and use requests to /assets with hardcoded types to

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-chi/httprate v0.14.1
 	github.com/google/uuid v1.6.0
 	github.com/lithammer/fuzzysearch v1.1.8
-	github.com/spf13/afero v1.11.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/mod v0.19.0
@@ -18,6 +17,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/logging v1.8.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/lipgloss v0.7.1 // indirect
@@ -38,6 +38,9 @@ require (
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/term v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	google.golang.org/genproto v0.0.0-20231106174013-bbf56f31fb17 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20231106174013-bbf56f31fb17 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -5,10 +5,10 @@ cloud.google.com/go/compute v1.23.3 h1:6sVlXXBmbd7jNX0Ipq0trII3e4n1/MsADLK6a+aiV
 cloud.google.com/go/compute v1.23.3/go.mod h1:VCgBUoMnIVIR0CscqQiPJLAG25E3ZRZMzcFZeQ+h8CI=
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
-cloud.google.com/go/logging v1.7.0 h1:CJYxlNNNNAMkHp9em/YEXcfJg+rPDg7YfwoRpMU+t5I=
-cloud.google.com/go/logging v1.7.0/go.mod h1:3xjP2CjkM3ZkO73aj4ASA5wRPGGCRrPIAeNqVNkzY8M=
-cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tErFDWI=
-cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
+cloud.google.com/go/logging v1.8.1 h1:26skQWPeYhvIasWKm48+Eq7oUqdcdbwsCVwz5Ys0FvU=
+cloud.google.com/go/logging v1.8.1/go.mod h1:TJjR+SimHwuC8MZ9cjByQulAMgni+RkXeI3wwctHJEI=
+cloud.google.com/go/longrunning v0.5.4 h1:w8xEcbZodnA2BbW6sVirkkoC+1gP8wS57EUUgGS0GVg=
+cloud.google.com/go/longrunning v0.5.4/go.mod h1:zqNVncI0BOP8ST6XQD1+VcvuShMmq7+xFSzOL++V0dI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -56,8 +56,6 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.4 h1:8TfxU8dW6PdqD27gjM8MVNuicgxIjxpm4K7x4jp8sis=
 github.com/rivo/uniseg v0.4.4/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=
-github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/storage/local.go
+++ b/storage/local.go
@@ -142,6 +142,10 @@ func (s *Local) AddExtension(ctx context.Context, manifest *VSIXManifest, vsix [
 	return dir, nil
 }
 
+func (s *Local) FileServer() http.Handler {
+	return http.FileServer(http.Dir(s.extdir))
+}
+
 func (s *Local) Open(_ context.Context, fp string) (fs.File, error) {
 	return http.Dir(s.extdir).Open(fp)
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -213,10 +213,9 @@ type Storage interface {
 	// for verification purposes. Extra files can be included, but not required.
 	// All extra files will be placed relative to the manifest outside the vsix.
 	AddExtension(ctx context.Context, manifest *VSIXManifest, vsix []byte, extra ...File) (string, error)
-	// Open mirrors the fs.FS interface of Open, except with a context.
-	// The Open should return files from the extension storage, and used for
-	// serving extensions.
-	Open(ctx context.Context, name string) (fs.File, error)
+	// FileServer provides a handler for fetching extension repository files from
+	// a client.
+	FileServer() http.Handler
 	// Manifest returns the manifest bytes for the provided extension.  The
 	// extension asset itself (the VSIX) will be included on the manifest even if
 	// it does not exist on the manifest on disk.
@@ -237,17 +236,6 @@ type Storage interface {
 	// [0]).  If the function returns an error the error is immediately returned
 	// which aborts the walk.
 	WalkExtensions(ctx context.Context, fn func(manifest *VSIXManifest, versions []Version) error) error
-}
-
-// HTTPFileServer creates an http.Handler that serves files from the provided
-// storage.
-func HTTPFileServer(s Storage) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		http.FileServerFS(&contextFs{
-			ctx:  r.Context(),
-			open: s.Open,
-		}).ServeHTTP(rw, r)
-	})
 }
 
 type File struct {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -201,7 +201,7 @@ func testFileServer(t *testing.T, factory storageFactory) {
 			req := httptest.NewRequest("GET", test.path, nil)
 			rec := httptest.NewRecorder()
 
-			server := storage.HTTPFileServer(f.storage)
+			server := f.storage.FileServer()
 			server.ServeHTTP(rec, req)
 
 			resp := rec.Result()

--- a/testutil/mockstorage.go
+++ b/testutil/mockstorage.go
@@ -3,13 +3,9 @@ package testutil
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"net/http"
 	"os"
-	"path/filepath"
 	"sort"
-
-	"github.com/spf13/afero/mem"
 
 	"github.com/coder/code-marketplace/storage"
 )
@@ -25,15 +21,6 @@ func NewMockStorage() *MockStorage {
 
 func (s *MockStorage) AddExtension(ctx context.Context, manifest *storage.VSIXManifest, vsix []byte, extra ...storage.File) (string, error) {
 	return "", errors.New("not implemented")
-}
-func (s *MockStorage) Open(ctx context.Context, path string) (fs.File, error) {
-	if filepath.Base(path) == "nonexistent" {
-		return nil, fs.ErrNotExist
-	}
-
-	f := mem.NewFileHandle(mem.CreateFile(path))
-	_, _ = f.Write([]byte("foobar"))
-	return f, nil
 }
 
 func (s *MockStorage) FileServer() http.Handler {


### PR DESCRIPTION
Allows bytes to be copied without reading them all into memory first.