### PR TITLE
chore(#89): allow specifying pod port

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -49,11 +49,11 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.service.port }}
               protocol: TCP
           args:
             - --address
-            - 0.0.0.0:80
+            - "0.0.0.0:{{ .Values.service.port }}"
             {{- if .Values.persistence.artifactory.enabled }}
             - --artifactory
             - {{ .Values.persistence.artifactory.uri }}


### PR DESCRIPTION
closes #89

As the service port is 80 by default, this does not changes the default port.