### PR TITLE
chore(#94): allow specifying other custom volumes

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -25,11 +25,16 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "code-marketplace.serviceAccountName" . }}
-      {{- if not .Values.persistence.artifactory.enabled }}
+      {{- if or (.Values.volumes) (not .Values.persistence.artifactory.enabled) }}
       volumes:
+      {{- if not .Values.persistence.artifactory.enabled }}
         - name: extensions
           persistentVolumeClaim:
             claimName: {{ include "code-marketplace.fullname" . }}
+      {{- end }}
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
@@ -63,10 +68,15 @@ spec:
             - --extensions-dir
             - /extensions
             {{- end }}
-          {{- if not .Values.persistence.artifactory.enabled }}
+          {{- if or (.Values.volumeMounts) (not .Values.persistence.artifactory.enabled) }}
           volumeMounts:
+          {{- if not .Values.persistence.artifactory.enabled }}
             - name: extensions
               mountPath: /extensions
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -77,6 +77,19 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
closes #94
Implemented with the same values as when you create a new helm chart with the latest version of helm `helm create mychart`