### PR TITLE
chore: Defined the spec.strategy.type field as Recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Updated the Kubernetes Deployment `spec.strategy.type` field to be of type `Recreate`
+  in order to properly handle upgrades/restarts as the default deployment creates a PVC
+  of type `ReadWriteOnce` and could only be assigned to one replica.
+
 ## [2.4.0](https://github.com/coder/code-marketplace/releases/tag/v2.4.0) - 2025-09-04
 
 ### Added

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -11,6 +11,8 @@ spec:
   selector:
     matchLabels:
       {{- include "code-marketplace.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
Updated the Kubernetes Deployment `spec.strategy.type` field to be of type `Recreate` in order to properly handle upgrades/restarts as the default deployment creates a PVC of type `ReadWriteOnce` and could only be assigned to one replica.

Existing behaviour results in replacement pods sitting in a waiting state because of volume attach failures.