### PR TITLE
chore: bump Go to v1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/coder/code-marketplace
 
-go 1.24.0
+go 1.24.11
 
 require (
 	cdr.dev/slog v1.6.1


### PR DESCRIPTION
## Summary

Bump Go from 1.24.0 to 1.24.11.

## Changes

- Updated `go.mod` to use Go 1.24.11

## Notes

This is a patch version bump with no breaking changes or dependency updates required.
